### PR TITLE
Front test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,23 @@ laravel11では私に色々不都合があったため10を指定する
 laravelの画面遷移時のフラッシュメッセージのような機能を実装しようとしたが｡  
 vue Routerの大きな仕様変更により難しくなった｡
 
+# 使ってるライブラリ
+[axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter)
+
+自分が使っているaxiosはカスタマイズしたやつなのでネットに乗ってる方法でやるのは難しいもよう｡  
+このライブラリを使ってカスタマイズしたaxiosをモックしている
+
 # 参考サイト
 
 ## laravel
 [Docker+Nginx+MySQLでLaravelの開発環境構築](https://entreprogrammer.jp/laravel-nginx-docker/)
+
+## vitest
+* [Vue/Jestテストのハマりどころ３選!!](https://tech-blog.rakus.co.jp/entry/20200206/vue-js/jest/software-test)
+* [Next/RouterのMock - Vitest](https://zenn.dev/renoa/articles/vitest-next-router-mock)
+* [Nuxt3でのVue Test Utilsでのvmがの中身が{}（空）の件](https://zenn.dev/tmo_taka/articles/91e040c081046a)
+
+## vue test utils
+* [Using-a-Real-Router](https://test-utils.vuejs.org/guide/advanced/vue-router#Using-a-Real-Router)
+* [wrapper](https://v1.test-utils.vuejs.org/ja/api/wrapper/)
+* [API Reference](https://test-utils.vuejs.org/api/)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
+    "axios-mock-adapter": "^1.22.0",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/frontend/src/__tests__/components/Task.spec.js
+++ b/frontend/src/__tests__/components/Task.spec.js
@@ -6,11 +6,6 @@ import Task from '@/components/Task.vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import { routes } from "@/router" 
 
-const router = createRouter({
-    history: createWebHistory(),
-    routes: routes,
-  })
-
 // 使いまわし用の基本のprops
 const baseProps = {
     task:{
@@ -19,6 +14,12 @@ const baseProps = {
         created_at:'2024-03-23T0000', // Tで切り分けるようにしてるからTが必要
     } 
 }
+
+// vue-routerの警告を消すために色々
+const router = createRouter({
+    history: createWebHistory(),
+    routes: routes,
+  })
 
 const baseWrapper = mount(Task,{
     props:baseProps,

--- a/frontend/src/__tests__/components/Task.spec.js
+++ b/frontend/src/__tests__/components/Task.spec.js
@@ -29,6 +29,8 @@ const baseWrapper = mount(Task,{
 
 test('レンダリング', () => {
     const wrapper = baseWrapper
+    const anker = wrapper.findAll('a')[0]
+    expect(anker.html()).toContain(baseProps.task.id)
     expect(wrapper.text()).toContain('testTask')
     expect(wrapper.text()).toContain('2024-03-23')
   })

--- a/frontend/src/__tests__/components/Task.spec.js
+++ b/frontend/src/__tests__/components/Task.spec.js
@@ -3,30 +3,43 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import Task from '@/components/Task.vue'
 
+import { createRouter, createWebHistory } from 'vue-router'
+import { routes } from "@/router" 
+
+const router = createRouter({
+    history: createWebHistory(),
+    routes: routes,
+  })
+
 // 使いまわし用の基本のprops
 const baseProps = {
-    props: { 
-        task:{
-            id:1,
-            task_name:'testTask',
-            created_at:'2024-03-23T0000', // Tで切り分けるようにしてるからTが必要
-        } 
-    }
+    task:{
+        id:1,
+        task_name:'testTask',
+        created_at:'2024-03-23T0000', // Tで切り分けるようにしてるからTが必要
+    } 
 }
 
+const baseWrapper = mount(Task,{
+    props:baseProps,
+    global: {
+      plugins: [router]
+    }
+})
+
 test('レンダリング', () => {
-    const wrapper = mount(Task,baseProps)
+    const wrapper = baseWrapper
     expect(wrapper.text()).toContain('testTask')
     expect(wrapper.text()).toContain('2024-03-23')
   })
 
 test('created_at',() => {
-    const wrapper = mount(Task,baseProps)
+    const wrapper = baseWrapper
     expect(wrapper.vm.created_at('2024-03-23T0000')).toBe('2024-03-23')
 })
 
 test('submit',() => {
-    const wrapper = mount(Task,baseProps)
+    const wrapper = baseWrapper
     const buttons = wrapper.findAll('button')
     // 見つけたボタンの中から完了ボタンを探す
     // textに完了って書いてるボタンを取得するとおもむろにそうなる

--- a/frontend/src/__tests__/views/index.spec.js
+++ b/frontend/src/__tests__/views/index.spec.js
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils'
+import Index  from '@/views/Index.vue'
+import {default as axios} from '@/tools/customizedAxios.js'
+import MockAdapter from 'axios-mock-adapter'
+import {router} from '@/router/index.js'
+import { createRouter, createWebHistory } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router';
+
+// const route = useRoute();
+// const router = useRouter();
+
+// const router = createRouter({
+//     history: createWebHistory(),
+//     routes: route
+//   })
+
+
+const baseURL = 'http://localhost:8000/api/task'
+
+
+test("初期状態",async () => {
+    // axiosを監視して、レスポンスのモックデータを設定
+    const url = baseURL + "/"
+
+
+
+    const mockedAxios = new MockAdapter(axios)
+    mockedAxios.onGet(url).reply(200,
+        [
+            {
+                id:1,
+                task_name:'testTask',
+                created_at:'2024-03-23T0000'
+            }
+        ]
+    )
+
+
+    // vi.mock("vue-router", () => ({
+    //     useRoute() {
+    //       return {
+    //         route: "/",
+    //         pathname: "",
+    //         query: "",
+    //         asPath: "",
+    //       };
+    //     },
+    //   }));
+
+    // const response = await axios.get(baseURL + "/")
+    // console.log(response.data);
+    // console.log("test");
+    // await router.isReady()
+    const wrapper = await mount(Index,
+        {
+            global: {
+              plugins: [router]
+            }
+        }
+    )
+    console.log(wrapper.vi.tasks);
+
+
+})

--- a/frontend/src/__tests__/views/index.spec.js
+++ b/frontend/src/__tests__/views/index.spec.js
@@ -1,64 +1,75 @@
-import { mount } from '@vue/test-utils'
+import { mount,RouterLinkStub } from '@vue/test-utils'
 import Index  from '@/views/Index.vue'
-import {default as axios} from '@/tools/customizedAxios.js'
+import customizedAxios from '@/tools/customizedAxios.js'
 import MockAdapter from 'axios-mock-adapter'
-import {router} from '@/router/index.js'
+import {routes} from '@/router/index.js'
 import { createRouter, createWebHistory } from 'vue-router'
-import { useRoute, useRouter } from 'vue-router';
 
-// const route = useRoute();
-// const router = useRouter();
-
-// const router = createRouter({
-//     history: createWebHistory(),
-//     routes: route
-//   })
-
+const router = createRouter({
+    history: createWebHistory(),
+    routes: routes,
+  })
 
 const baseURL = 'http://localhost:8000/api/task'
 
 
-test("初期状態",async () => {
+test("とりあえず初期状態",async () => {
     // axiosを監視して、レスポンスのモックデータを設定
     const url = baseURL + "/"
 
+    const mockedResponse = [
+        {
+            id:1,
+            task_name:'testTask',
+            created_at:'2024-03-23T0000'
+        }
+    ]
 
+    // ライブラリを使った方法ならできた -> ただこのライブラリに依存することになる
+    // axiosをモックする
+    const mockedAxios = new MockAdapter(customizedAxios)
+    mockedAxios.onGet(url).reply(200,mockedResponse)
 
-    const mockedAxios = new MockAdapter(axios)
-    mockedAxios.onGet(url).reply(200,
-        [
-            {
-                id:1,
-                task_name:'testTask',
-                created_at:'2024-03-23T0000'
-            }
-        ]
-    )
+    vi.mock('vue-router', async () => {
+        const route = await vi.importActual('vue-router')
+      
+        return { ...route, 
+            useRoute() {
+                return {
+                  route: "/",
+                  pathname: "",
+                  query: {keyword:""},
+                  asPath: "",
+                };
+              },
+        }
+    })
 
-
-    // vi.mock("vue-router", () => ({
-    //     useRoute() {
-    //       return {
-    //         route: "/",
-    //         pathname: "",
-    //         query: "",
-    //         asPath: "",
-    //       };
-    //     },
-    //   }));
-
+    // なぜこれで帰ってくるのか正直わからない?
+    // axiosがmockされて改変されているから?
     // const response = await axios.get(baseURL + "/")
     // console.log(response.data);
-    // console.log("test");
+    // const response = await customizedAxios.get(baseURL + "/")
+
     // await router.isReady()
     const wrapper = await mount(Index,
         {
             global: {
-              plugins: [router]
-            }
+                plugins: [router],
+                stubs: {RouterLink: RouterLinkStub},
+            },
         }
     )
-    console.log(wrapper.vi.tasks);
 
+    // BeforeMountでやってること再現しないとだめだってさ｡
+    wrapper.vm.keyword = ''
+    await wrapper.vm.search()
+
+
+    // console.log(wrapper.vm.tasks);
+    // console.log(wrapper.vm.route.query); 
+
+    // axiosで通信したデータが変数に入っているか
+    expect(wrapper.vm.tasks).toContainEqual(mockedResponse[0]);
 
 })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,25 +3,27 @@ import Index  from '@/views/Index.vue'
 import Create  from '@/views/Create.vue'
 import Edit  from '@/views/Edit.vue'
 
+const routes = [
+  {
+    path: '/',
+    name: 'index',
+    component: Index
+  },
+  {
+    path: '/create',
+    name: 'create',
+    component: Create
+  },
+  {
+    path: '/edit/:id',
+    name: 'edit',
+    component: Edit
+  },
+]
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL + 'task'),
-  routes: [
-    {
-      path: '/',
-      name: 'index',
-      component: Index
-    },
-    {
-      path: '/create',
-      name: 'create',
-      component: Create
-    },
-    {
-      path: '/edit/:id',
-      name: 'edit',
-      component: Edit
-    },
-  ]
+  routes: routes
 })
-
+export { routes }
 export default router

--- a/frontend/src/views/Index.vue
+++ b/frontend/src/views/Index.vue
@@ -11,6 +11,8 @@ let loading = ref(true)
 let tasks = ref(null)
 let keyword = ref('')
 
+defineExpose({tasks})
+
 onBeforeMount(async () => {
     keyword.value = route.query.keyword || ''; // URL のクエリパラメーターを取得
     await search()

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -975,6 +975,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios-mock-adapter@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz#0f3e6be0fc9b55baab06f2d49c0b71157e7c053d"
+  integrity sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.5"
+
 axios@^1.6.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
@@ -1723,6 +1731,11 @@ ini@^1.3.4:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-docker@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
やっと初期状態までテストができた｡
mock系難しすぎ､ややこしすぎ､まどろっこしすぎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アプリに検索機能のテストを追加しました。
	- `axios-mock-adapter`ライブラリに関するセクションをREADMEに追加し、Axiosのカスタマイズ方法について説明しました。
	- Laravel、Vueテスト、Vue Test Utilsに関する参考文献をREADMEに追加しました。
	- Vueコンポーネントの初期状態をテストするための新しいテストスクリプトを追加しました。

- **バグ修正**
	- Vue Routerの警告に対処するために、ルーターの設定を導入しました。

- **リファクタリング**
	- ルーター設定の可読性と保守性を向上させるために、ルート定義を`routes`配列に移動しました。
	- `Task`コンポーネントのテストで直接の`mount`呼び出しを`baseWrapper`を使用するように変更しました。

- **ドキュメンテーション**
	- Vueテストに関するドキュメンテーションを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->