### PR TITLE
playwrightでindex.vueのテスト

### DIFF
--- a/frontend/e2e/Index.spec.js
+++ b/frontend/e2e/Index.spec.js
@@ -2,9 +2,35 @@ import { test, expect,chromium} from '@playwright/test';
 
 const apiBaseURL = 'http://localhost:8000/api/task'
 
-// 画面遷移
-//  新規
-//  編集
+// propsで使うやつまできっちりとってこような!!
+const mockedResponseJson =[{
+    id: 1, 
+    task_name: 'test_task_name',
+    deleted_at: null,
+    created_at: '2024-03-23T07:41:42.000000Z', 
+    updated_at: '2024-03-23T07:41:42.000000Z'
+}]
+
+test('データ表示',async({page}) => {
+    await page.route(apiBaseURL + "/" + "?keyword=", async route => {
+        await route.fulfill({
+            status:200,
+            body: JSON.stringify(mockedResponseJson),
+        });
+    });
+
+    await page.route(apiBaseURL + "/" + "?keyword=", async route => {
+        await route.fulfill({
+            status:200,
+            body: JSON.stringify(mockedResponseJson),
+        });
+    });
+
+    await page.goto('/')
+
+    await expect(page.getByText(mockedResponseJson[0].task_name)).toBeVisible();
+    await expect(page.getByText(mockedResponseJson[0].created_at.split("T")[0])).toBeVisible();
+})
 
 test('検索', async ({ page }) => {
     await page.goto('/');
@@ -33,14 +59,6 @@ test.describe('画面遷移', () => {
     })
 
     test('編集', async ({page}) => { 
-        // propsで使うやつまできっちりとってこような!!
-        const mockedResponseJson =[{
-            id: 1, 
-            task_name: 'test_task_name',
-            deleted_at: null,
-            created_at: '2024-03-23T07:41:42.000000Z', 
-            updated_at: '2024-03-23T07:41:42.000000Z'
-        }]
 
         // http://localhost:8000/api/task/?keyword=
         await page.route(apiBaseURL + "/" + "?keyword=", async route => {
@@ -50,13 +68,14 @@ test.describe('画面遷移', () => {
             });
         });
 
-        const [request, response] = await Promise.all([
-            page.waitForRequest(request => request.url().includes(apiBaseURL)),
-            page.waitForResponse(response => response.url().includes(apiBaseURL)),
-            page.goto('/')
-        ])
+        await page.goto('/')
 
-        await expect(page.getByText(mockedResponseJson[0].task_name)).toBeVisible();
+        // デバックで使ってたやつ
+        // const [request, response] = await Promise.all([
+        //     page.waitForRequest(request => request.url().includes(apiBaseURL)),
+        //     page.waitForResponse(response => response.url().includes(apiBaseURL)),
+        //     page.goto('/')
+        // ])
 
         // ボタンを推して画面遷移
         const button = page.getByRole('button',{name:'編集'})

--- a/frontend/e2e/Index.spec.js
+++ b/frontend/e2e/Index.spec.js
@@ -1,0 +1,70 @@
+import { test, expect,chromium} from '@playwright/test';
+
+const apiBaseURL = 'http://localhost:8000/api/task'
+
+// 画面遷移
+//  新規
+//  編集
+
+test('検索', async ({ page }) => {
+    await page.goto('/');
+    const input = await page.getByRole('textbox')
+    await input.click()
+    await input.fill('test');
+
+    const submit = await page.getByRole('button',{name:'検索'})
+    await submit.click()
+
+    const url = page.url()
+    const regex = new RegExp('(?<=keyword=)(.*)')
+    await expect(regex.test(url)).toBe(true)
+})
+
+// playwrightはtest.describe
+test.describe('画面遷移', () => { 
+    test('新規', async ({page}) => { 
+        await page.goto('/');
+
+        const button = await page.getByRole('button',{name:'新規'})
+        await button.click()
+
+        const url = page.url()
+        await expect(url.includes('create')).toBe(true)
+    })
+
+    test('編集', async ({page}) => { 
+        // propsで使うやつまできっちりとってこような!!
+        const mockedResponseJson =[{
+            id: 1, 
+            task_name: 'test_task_name',
+            deleted_at: null,
+            created_at: '2024-03-23T07:41:42.000000Z', 
+            updated_at: '2024-03-23T07:41:42.000000Z'
+        }]
+
+        // http://localhost:8000/api/task/?keyword=
+        await page.route(apiBaseURL + "/" + "?keyword=", async route => {
+            await route.fulfill({
+                status:200,
+                body: JSON.stringify(mockedResponseJson),
+            });
+        });
+
+        const [request, response] = await Promise.all([
+            page.waitForRequest(request => request.url().includes(apiBaseURL)),
+            page.waitForResponse(response => response.url().includes(apiBaseURL)),
+            page.goto('/')
+        ])
+
+        await expect(page.getByText(mockedResponseJson[0].task_name)).toBeVisible();
+
+        // ボタンを推して画面遷移
+        const button = page.getByRole('button',{name:'編集'})
+        await button.click()
+
+        const url = page.url()
+        await expect(url.includes('edit/1')).toBe(true)
+    })
+ })
+
+ 

--- a/frontend/e2e/Index.spec.js
+++ b/frontend/e2e/Index.spec.js
@@ -19,13 +19,6 @@ test('データ表示',async({page}) => {
         });
     });
 
-    await page.route(apiBaseURL + "/" + "?keyword=", async route => {
-        await route.fulfill({
-            status:200,
-            body: JSON.stringify(mockedResponseJson),
-        });
-    });
-
     await page.goto('/')
 
     await expect(page.getByText(mockedResponseJson[0].task_name)).toBeVisible();

--- a/frontend/e2e/vue.spec.js
+++ b/frontend/e2e/vue.spec.js
@@ -1,8 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-// See here how to get started:
-// https://playwright.dev/docs/intro
-test('visits the app root url', async ({ page }) => {
-  await page.goto('/');
-  await expect(page.locator('div.greetings > h1')).toHaveText('You did it!');
-})

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -40,17 +40,18 @@ export default defineConfig({
     trace: 'on-first-retry',
 
     /* Only on CI systems run the tests headless */
-    headless: !!process.env.CI
+    // headless: !!process.env.CI
+    headless: true
   },
 
   /* Configure projects for major browsers */
   projects: [
-    // {
-    //   name: 'chromium',
-    //   use: {
-    //     ...devices['Desktop Chrome']
-    //   }
-    // },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome']
+      }
+    },
     // {
     //   name: 'firefox',
     //   use: {
@@ -85,12 +86,12 @@ export default defineConfig({
     //     channel: 'msedge',
     //   },
     // },
-    {
-      name: 'Google Chrome',
-      use: {
-        channel: 'chrome',
-      },
-    },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -45,24 +45,24 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome']
-      }
-    },
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox']
-      }
-    },
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari']
-      }
-    }
+    // {
+    //   name: 'chromium',
+    //   use: {
+    //     ...devices['Desktop Chrome']
+    //   }
+    // },
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox']
+    //   }
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     ...devices['Desktop Safari']
+    //   }
+    // }
 
     /* Test against mobile viewports. */
     // {
@@ -85,12 +85,12 @@ export default defineConfig({
     //     channel: 'msedge',
     //   },
     // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: {
-    //     channel: 'chrome',
-    //   },
-    // },
+    {
+      name: 'Google Chrome',
+      use: {
+        channel: 'chrome',
+      },
+    },
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */

--- a/frontend/src/views/Create.vue
+++ b/frontend/src/views/Create.vue
@@ -35,7 +35,7 @@ const setErrorMessage = (error) => {
     // ネットワークエラーと処理失敗は別物らしい
     try {
         errorMessage.value = error.response.data.message
-    } catch (error) {
+    } catch (innerError) {
         // ここに来たということは｡サーバーから送られたメッセージではないということ
         errorMessage.value = "エラーが発生しました｡時間を置いて再度送信して下さい｡"
     }

--- a/frontend/src/views/Edit.vue
+++ b/frontend/src/views/Edit.vue
@@ -72,7 +72,7 @@ const setErrorMessage = (error) => {
     // ネットワークエラーと処理失敗は別物らしい
     try {
         errorMessage.value = error.response.data.message
-    } catch (error) {
+    } catch (innerError) {
         // ここに来たということは｡サーバーから送られたメッセージではないということ
         errorMessage.value = "エラーが発生しました｡時間を置いて再度送信して下さい｡"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- フロントエンドアプリケーションのためのPlaywrightテストケースを追加しました。これには、データ表示、検索機能、ページナビゲーション（作成および編集）のテストが含まれます。

- **バグ修正**
	- `Create.vue` および `Edit.vue` ファイル内で、`setErrorMessage` 関数内のキャッチ変数を `error` から `innerError` に変更し、ネットワークエラーと処理失敗を区別しました。

- **テスト**
	- Playwright設定において、`headless` オプションを `true` に明示的に設定しました。また、FirefoxとWebkitブラウザの設定をコメントアウトしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->